### PR TITLE
Fix not working on my device

### DIFF
--- a/modules/midi.js
+++ b/modules/midi.js
@@ -51,13 +51,13 @@ async function midi_connect(controller_name) {
   let input, output;
 
   midiAccess.inputs.forEach((entry) => {
-    if (entry.name === controller_name) {
+    if (entry.name.startsWith(controller_name)) {
       input = entry;
       //input.onmidimessage = onMIDIMessage;
     }
   });
   midiAccess.outputs.forEach((entry) => {
-    if (entry.name === controller_name) {
+    if (entry.name.startsWith(controller_name)) {
       output = entry;
     }
   });


### PR DESCRIPTION
Hab das Problem gefunden :) Bei mir wird das device unter "Launchpad Mini MIDI 1" gelistet und nicht "Launchpad Mini" wie du es hardcoded hast. Hab deshalb einfach `===` durch `.startsWith()` ersetzt.